### PR TITLE
Add RUSD for compatibleXudt list

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,11 @@ jobs:
       - uses: actions/setup-node@v3.5.0
         with:
           node-version: '20'
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v3
+        name: Install -g pnpm
         with:
-          version: 8
+          version: 9
+          run_install: false
       - name: Install dependency
         run: pnpm install
       - name: Lint

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,9 +15,12 @@ jobs:
       - uses: actions/setup-node@v3.5.0
         with:
           node-version: '20'
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v3
+        name: Install -g pnpm
         with:
-          version: 8
+          version: 9
+          run_install: false
+          
       - name: Install dependency
         run: pnpm install
 

--- a/deployment/cell-deps.json
+++ b/deployment/cell-deps.json
@@ -62,5 +62,21 @@
       },
       "depType": "code"
     }
+  },
+  "compatibleXudt": {
+    "0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb": {
+      "outPoint": {
+        "index": "0x0",
+        "txHash": "0xed7d65b9ad3d99657e37c4285d585fea8a5fcaf58165d54dacf90243f911548b"
+      },
+      "depType": "code"
+    },
+    "0x26a33e0815888a4a0614a0b7d09fa951e0993ff21e55905510104a0b1312032b": {
+      "outPoint": {
+        "index": "0x0",
+        "txHash": "0x8ec1081bd03e5417bb4467e96f4cec841acdd35924538a35e7547fe320118977"
+      },
+      "depType": "code"
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 import { Collector } from '@rgbpp-sdk/ckb';
 import * as fs from 'fs';
 import * as path from 'path';
-import { fetchBtcTimeCellDep, fetchRgbppCellDep, fetchUniqueTestnetCellDep, fetchXudtTestnetCellDep } from './typeid';
+import {
+  fetchBtcTimeCellDep,
+  fetchCompatibleXudtCellDeps,
+  fetchRgbppCellDep,
+  fetchUniqueTestnetCellDep,
+  fetchXudtTestnetCellDep,
+} from './typeid';
 
 interface CellDepsObject {
   rgbpp: {
@@ -19,6 +25,9 @@ interface CellDepsObject {
   };
   unique: {
     testnet: CKBComponents.CellDep;
+  };
+  compatibleXudt: {
+    [codeHash: string]: CKBComponents.CellDep;
   };
 }
 
@@ -49,6 +58,7 @@ const fetchAndUpdateCellDeps = async () => {
     unique: {
       testnet: await fetchUniqueTestnetCellDep(testnetCollector),
     },
+    compatibleXudt: await fetchCompatibleXudtCellDeps(testnetCollector, mainnetCollector),
   };
 
   // Convert the object to JSON string

--- a/src/typeid.ts
+++ b/src/typeid.ts
@@ -1,6 +1,6 @@
 import { Collector } from '@rgbpp-sdk/ckb';
 
-export type BTCNetworkType = 'Mainnet' | 'Testnet3' | 'Signet'
+export type BTCNetworkType = 'Mainnet' | 'Testnet3' | 'Signet';
 
 const TYPEID_DEPLOYMENT_TYPE_SCRIPT: CKBComponents.Script = {
   codeHash: '0x00000000000000000000000000000000000000000000000000545950455f4944',
@@ -10,31 +10,31 @@ const TYPEID_DEPLOYMENT_TYPE_SCRIPT: CKBComponents.Script = {
 
 const rgbppDeploymentTypeScript = (btcNetworkType: BTCNetworkType): CKBComponents.Script => {
   // Get the mainnet type script of the output(https://explorer.nervos.org/transaction/0x04c5c3e69f1aa6ee27fb9de3d15a81704e387ab3b453965adbe0b6ca343c6f41#0)
-  let args = '0x68ad3d9e0bb9ea841a5d1fcd600137bd3f45401e759e353121f26cd0d981452f'
+  let args = '0x68ad3d9e0bb9ea841a5d1fcd600137bd3f45401e759e353121f26cd0d981452f';
   if (btcNetworkType === 'Testnet3') {
     // Get the testnet type script of the output(https://pudge.explorer.nervos.org/transaction/0xa3bc8441df149def76cfe15fec7b1e51d949548bc27fb7a75e9d4b3ef1c12c7f#0)
-    args = '0xa3bc8441df149def76cfe15fec7b1e51d949548bc27fb7a75e9d4b3ef1c12c7f'
+    args = '0xa3bc8441df149def76cfe15fec7b1e51d949548bc27fb7a75e9d4b3ef1c12c7f';
   } else if (btcNetworkType === 'Signet') {
-    args = '0xb69fe766ce3b7014a2a78ad1fe688d82f1679325805371d2856c3b8d18ebfa5a'
+    args = '0xb69fe766ce3b7014a2a78ad1fe688d82f1679325805371d2856c3b8d18ebfa5a';
   }
   return {
     ...TYPEID_DEPLOYMENT_TYPE_SCRIPT,
-    args
+    args,
   };
 };
 
 const btcTimeDeploymentTypeScript = (btcNetworkType: BTCNetworkType): CKBComponents.Script => {
   // Get the mainnet type script of the output(https://explorer.nervos.org/transaction/0x6257bf4297ee75fcebe2654d8c5f8d93bc9fc1b3dc62b8cef54ffe166162e996#0)
-  let args = '0x44b8253ae18e913a2845b0d548eaf6b3ba1099ed26835888932a754194028a8a'
+  let args = '0x44b8253ae18e913a2845b0d548eaf6b3ba1099ed26835888932a754194028a8a';
   if (btcNetworkType === 'Testnet3') {
     // Get the testnet type script of the output(https://pudge.explorer.nervos.org/transaction/0xde0f87878a97500f549418e5d46d2f7704c565a262aa17036c9c1c13ad638529#0)
-    args = '0xc9828585e6dd2afacb9e6e8ca7deb0975121aabee5c7983178a45509ffaec984'
+    args = '0xc9828585e6dd2afacb9e6e8ca7deb0975121aabee5c7983178a45509ffaec984';
   } else if (btcNetworkType === 'Signet') {
-    args = '0x32fc8c70a6451a1439fd91e214bba093f9cdd9276bc4ab223430dab5940aff92'
+    args = '0x32fc8c70a6451a1439fd91e214bba093f9cdd9276bc4ab223430dab5940aff92';
   }
   return {
     ...TYPEID_DEPLOYMENT_TYPE_SCRIPT,
-    args
+    args,
   };
 };
 
@@ -54,7 +54,33 @@ const xudtTestnetDeploymentTypeScript = (): CKBComponents.Script => {
   };
 };
 
-export const fetchRgbppCellDep = async (collector: Collector, btcNetworkType: BTCNetworkType): Promise<CKBComponents.CellDep> => {
+const rusdCodeHashAndDeploymentTypeScript = (isMainnet: boolean) => {
+  const codeHash = isMainnet
+    ? '0x26a33e0815888a4a0614a0b7d09fa951e0993ff21e55905510104a0b1312032b'
+    : '0x25c29dc317811a6f6f3985a7a9ebc4838bd388d19d0feeecf0bcd60f6c0975bb';
+  return isMainnet
+    ? {
+        codeHash,
+        typeScript: {
+          ...TYPEID_DEPLOYMENT_TYPE_SCRIPT,
+          // Get the mainnet type script of the output(https://explorer.nervos.org/transaction/0x8ec1081bd03e5417bb4467e96f4cec841acdd35924538a35e7547fe320118977#0)
+          args: '0x953400cc4c55f1b0623faca8d90c5257eaa449a7d22179b5178d67fbf7f51bc2',
+        },
+      }
+    : {
+        codeHash,
+        typeScript: {
+          ...TYPEID_DEPLOYMENT_TYPE_SCRIPT,
+          // Get the testnet type script of the output(https://testnet.explorer.nervos.org/transaction/0xed7d65b9ad3d99657e37c4285d585fea8a5fcaf58165d54dacf90243f911548b#0)
+          args: '0x97d30b723c0b2c66e9cb8d4d0df4ab5d7222cbb00d4a9a2055ce2e5d7f0d8b0f',
+        },
+      };
+};
+
+export const fetchRgbppCellDep = async (
+  collector: Collector,
+  btcNetworkType: BTCNetworkType,
+): Promise<CKBComponents.CellDep> => {
   const [cell] = await collector.getCells({ type: rgbppDeploymentTypeScript(btcNetworkType) });
   if (!cell) {
     throw new Error('No rgbpp lock deployment live cell found');
@@ -66,7 +92,10 @@ export const fetchRgbppCellDep = async (collector: Collector, btcNetworkType: BT
   return rgbppLockDep;
 };
 
-export const fetchBtcTimeCellDep = async (collector: Collector, btcNetworkType: BTCNetworkType): Promise<CKBComponents.CellDep> => {
+export const fetchBtcTimeCellDep = async (
+  collector: Collector,
+  btcNetworkType: BTCNetworkType,
+): Promise<CKBComponents.CellDep> => {
   const [cell] = await collector.getCells({ type: btcTimeDeploymentTypeScript(btcNetworkType) });
   if (!cell) {
     throw new Error('No BTC time lock deployment live cell found');
@@ -98,4 +127,28 @@ export const fetchUniqueTestnetCellDep = async (collector: Collector): Promise<C
     outPoint: cell.outPoint,
     depType: 'code',
   };
+};
+
+export const fetchCompatibleXudtCellDeps = async (
+  testnetCollector: Collector,
+  mainnetCollector: Collector,
+): Promise<{ [codeHash: string]: CKBComponents.CellDep }> => {
+  let cellDeps: { [codeHash: string]: CKBComponents.CellDep } = {};
+  for (const collector of [testnetCollector, mainnetCollector]) {
+    const pairs = [rusdCodeHashAndDeploymentTypeScript(collector === mainnetCollector)];
+    for (const { codeHash, typeScript } of pairs) {
+      const [cell] = await collector.getCells({ type: typeScript });
+      if (!cell) {
+        throw new Error('No compatible xudt type deployment live cell found');
+      }
+      cellDeps = {
+        ...cellDeps,
+        [codeHash]: {
+          outPoint: cell.outPoint,
+          depType: 'code',
+        },
+      };
+    }
+  }
+  return cellDeps;
 };


### PR DESCRIPTION
## Changes

- Use RUSD deployment type script to fetch the `cellDeps` to build RUSD transactions
- Use RUSD type script code hash as the key name to find the correct compatible xUDT assets